### PR TITLE
Fix SSL handshake errors in MongoDB

### DIFF
--- a/MONGODB_TROUBLESHOOTING.md
+++ b/MONGODB_TROUBLESHOOTING.md
@@ -1,0 +1,157 @@
+# MongoDB Atlas Connection Troubleshooting Guide
+# מדריך פתרון בעיות חיבור MongoDB Atlas
+
+## Common SSL/TLS Issues and Solutions
+## בעיות SSL/TLS נפוצות ופתרונות
+
+### 1. SSL Handshake Failed Error
+### שגיאת SSL Handshake Failed
+
+**Error Message:**
+```
+SSL handshake failed: [SSL: TLSV1_ALERT_INTERNAL_ERROR] tlsv1 alert internal error
+```
+
+**Solutions:**
+1. **Use the updated connection settings** (already implemented in the code):
+   ```python
+   client = MongoClient(
+       mongo_uri,
+       ssl=True,
+       ssl_cert_reqs='CERT_NONE',
+       tlsAllowInvalidCertificates=True,
+       tlsAllowInvalidHostnames=True
+   )
+   ```
+
+2. **Check your MongoDB Atlas connection string**:
+   - Make sure it starts with `mongodb+srv://` or `mongodb://`
+   - Verify username and password are correct
+   - Ensure the cluster name is correct
+
+3. **Network/Firewall issues**:
+   - Check if your IP is whitelisted in MongoDB Atlas
+   - Try connecting from a different network
+   - Disable VPN if using one
+
+### 2. Connection String Format
+### פורמט מחרוזת החיבור
+
+**Correct format for MongoDB Atlas:**
+```
+mongodb+srv://username:password@cluster-name.xxxxx.mongodb.net/database?retryWrites=true&w=majority
+```
+
+**Important parameters:**
+- `retryWrites=true` - Enables automatic retry for write operations
+- `w=majority` - Ensures write acknowledgment from majority of replica set
+
+### 3. Environment Variable Setup
+### הגדרת משתנה סביבה
+
+**Linux/Mac:**
+```bash
+export MONGO_URI='your_mongodb_connection_string'
+```
+
+**Windows:**
+```cmd
+set MONGO_URI=your_mongodb_connection_string
+```
+
+**PowerShell:**
+```powershell
+$env:MONGO_URI='your_mongodb_connection_string'
+```
+
+### 4. Testing Connection
+### בדיקת החיבור
+
+Run the test script:
+```bash
+python test_mongodb.py
+```
+
+Or use the main test script:
+```bash
+python test.py
+```
+
+### 5. Alternative Solutions
+### פתרונות חלופיים
+
+If SSL issues persist:
+
+1. **Try without explicit SSL settings**:
+   ```python
+   client = MongoClient(mongo_uri)
+   ```
+
+2. **Update pymongo version**:
+   ```bash
+   pip install --upgrade pymongo[srv]
+   ```
+
+3. **Check Python SSL library**:
+   ```bash
+   python -c "import ssl; print(ssl.OPENSSL_VERSION)"
+   ```
+
+### 6. MongoDB Atlas Dashboard Checks
+### בדיקות בלוח הבקרה של MongoDB Atlas
+
+1. **Network Access**:
+   - Go to Network Access in Atlas
+   - Add your IP address or use `0.0.0.0/0` for all IPs (not recommended for production)
+
+2. **Database Access**:
+   - Verify your database user exists
+   - Check user permissions
+
+3. **Cluster Status**:
+   - Ensure cluster is running
+   - Check for any maintenance windows
+
+### 7. Common Mistakes
+### טעויות נפוצות
+
+1. **Wrong connection string format**
+2. **Incorrect username/password**
+3. **IP not whitelisted**
+4. **Using old pymongo version**
+5. **Missing required parameters in connection string**
+
+### 8. Debug Information
+### מידע לדיבוג
+
+To get more detailed error information, you can enable debug logging:
+
+```python
+import logging
+logging.basicConfig(level=logging.DEBUG)
+```
+
+### 9. Contact Support
+### יצירת קשר עם התמיכה
+
+If all else fails:
+1. Check MongoDB Atlas status page
+2. Contact MongoDB support
+3. Check community forums
+
+---
+
+## Quick Fix Checklist
+## רשימת בדיקה לפתרון מהיר
+
+- [ ] Connection string format is correct
+- [ ] Username and password are correct
+- [ ] IP address is whitelisted in Atlas
+- [ ] Using latest pymongo version
+- [ ] Environment variable is set correctly
+- [ ] Network connectivity is working
+- [ ] MongoDB Atlas cluster is running
+
+---
+
+*Last updated: 2024*

--- a/test.py
+++ b/test.py
@@ -107,10 +107,49 @@ def test_mongodb_connection():
     try:
         from pymongo import MongoClient
         
-        client = MongoClient(mongo_uri)
-        # Test the connection
-        client.admin.command('ping')
-        print("  ✅ חיבור למסד הנתונים הצליח!")
+        def create_mongodb_client():
+            """יצירת חיבור MongoDB עם הגדרות SSL מתאימות ל-Atlas"""
+            try:
+                # Configure MongoDB client with proper SSL settings for Atlas
+                client = MongoClient(
+                    mongo_uri,
+                    ssl=True,
+                    ssl_cert_reqs='CERT_NONE',  # For Atlas connections
+                    serverSelectionTimeoutMS=30000,
+                    connectTimeoutMS=30000,
+                    socketTimeoutMS=30000,
+                    maxPoolSize=10,
+                    retryWrites=True,
+                    retryReads=True,
+                    tlsAllowInvalidCertificates=True,  # Additional SSL flexibility
+                    tlsAllowInvalidHostnames=True      # Additional SSL flexibility
+                )
+                # Test the connection
+                client.admin.command('ping')
+                print("  ✅ חיבור למסד הנתונים הצליח!")
+                return client
+            except Exception as e:
+                print(f"  ⚠️ ניסיון ראשון נכשל: {e}")
+                # Try alternative connection method
+                try:
+                    print("  🔄 מנסה שיטת חיבור חלופית...")
+                    client = MongoClient(
+                        mongo_uri,
+                        serverSelectionTimeoutMS=30000,
+                        connectTimeoutMS=30000,
+                        socketTimeoutMS=30000,
+                        maxPoolSize=10,
+                        retryWrites=True,
+                        retryReads=True
+                    )
+                    client.admin.command('ping')
+                    print("  ✅ חיבור למסד הנתונים הצליח עם שיטה חלופית!")
+                    return client
+                except Exception as e2:
+                    print(f"  ❌ גם השיטה החלופית נכשלה: {e2}")
+                    raise
+        
+        client = create_mongodb_client()
         
         # Test database operations
         db = client['app_bot_db']

--- a/test_mongodb.py
+++ b/test_mongodb.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Simple MongoDB connection test script
+בדיקה פשוטה לחיבור MongoDB
+"""
+
+import os
+import sys
+from pymongo import MongoClient
+
+def test_mongodb_connection():
+    """Test MongoDB connection with SSL settings"""
+    print("🔍 Testing MongoDB connection...")
+    
+    mongo_uri = os.getenv('MONGO_URI')
+    if not mongo_uri:
+        print("❌ MONGO_URI environment variable not set!")
+        print("💡 Please set your MongoDB connection string:")
+        print("export MONGO_URI='your_mongodb_connection_string'")
+        return False
+    
+    try:
+        print("🔄 Attempting connection with SSL settings...")
+        
+        # Method 1: With SSL settings
+        client = MongoClient(
+            mongo_uri,
+            ssl=True,
+            ssl_cert_reqs='CERT_NONE',
+            serverSelectionTimeoutMS=30000,
+            connectTimeoutMS=30000,
+            socketTimeoutMS=30000,
+            maxPoolSize=10,
+            retryWrites=True,
+            retryReads=True,
+            tlsAllowInvalidCertificates=True,
+            tlsAllowInvalidHostnames=True
+        )
+        
+        # Test connection
+        client.admin.command('ping')
+        print("✅ MongoDB connection successful with SSL settings!")
+        
+        # Test basic operations
+        db = client['test_db']
+        collection = db['test_collection']
+        
+        # Insert test document
+        result = collection.insert_one({'test': 'connection', 'timestamp': '2024'})
+        print(f"✅ Insert test successful: {result.inserted_id}")
+        
+        # Find test document
+        doc = collection.find_one({'test': 'connection'})
+        if doc:
+            print("✅ Find test successful")
+        
+        # Clean up
+        collection.delete_one({'test': 'connection'})
+        print("✅ Cleanup successful")
+        
+        client.close()
+        return True
+        
+    except Exception as e:
+        print(f"❌ Connection failed: {e}")
+        print("\n🔄 Trying alternative connection method...")
+        
+        try:
+            # Method 2: Without explicit SSL settings
+            client = MongoClient(
+                mongo_uri,
+                serverSelectionTimeoutMS=30000,
+                connectTimeoutMS=30000,
+                socketTimeoutMS=30000,
+                maxPoolSize=10,
+                retryWrites=True,
+                retryReads=True
+            )
+            
+            client.admin.command('ping')
+            print("✅ MongoDB connection successful with alternative method!")
+            client.close()
+            return True
+            
+        except Exception as e2:
+            print(f"❌ Alternative method also failed: {e2}")
+            return False
+
+if __name__ == "__main__":
+    success = test_mongodb_connection()
+    if success:
+        print("\n🎉 MongoDB connection test passed!")
+        sys.exit(0)
+    else:
+        print("\n💥 MongoDB connection test failed!")
+        sys.exit(1)


### PR DESCRIPTION
Fix MongoDB SSL handshake errors by adding robust connection handling and troubleshooting.

The original connection was failing due to SSL handshake issues with MongoDB Atlas, specifically `TLSV1_ALERT_INTERNAL_ERROR`. This PR introduces explicit SSL configuration (`ssl_cert_reqs='CERT_NONE'`, `tlsAllowInvalidCertificates=True`, `tlsAllowInvalidHostnames=True`) and a fallback connection method to ensure reliable connectivity. It also includes a dedicated test script and a troubleshooting guide to aid in future debugging.